### PR TITLE
refactor: removed application level transactions

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -173,7 +173,7 @@ func main() {
 	gitService := git.NewService(pgRepo)
 
 	blockService := blocks.NewService(pgRepo, snapshotService, lockService, config.LexoRankThreshold)
-	courseService := courses.NewService(pgRepo, snapshotService, lockService, pgRepo)
+	courseService := courses.NewService(pgRepo, snapshotService, lockService)
 
 	userHandler := users.NewHandler(userService)
 	blockHandler := blocks.NewHandler(blockService)

--- a/internal/courses/repo.go
+++ b/internal/courses/repo.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jmoiron/sqlx"
 )
 
 type CourseMemberRole string
@@ -37,12 +36,6 @@ type CreateCourse struct {
 type UpdateCourse struct {
 	OwnerID uuid.UUID `json:"ownerID,omitempty" db:"owner_id"`
 	Name    string    `json:"name,omitempty"    db:"name"`
-}
-
-type PublishSnapshot struct {
-	CourseID        uuid.UUID `json:"courseID"`
-	NewSnapshotID   uuid.UUID `json:"newSnapshotID"`
-	ExpectedVersion int       `json:"expectedVersion"`
 }
 
 // CourseMember is the database representation of a course member.
@@ -102,9 +95,10 @@ type InviteDetails struct {
 }
 
 type Repo interface {
-	CreateCourse(
+	// CreateCourseWithInitialSnapshot atomically creates a course together with
+	// its first published snapshot and links them.
+	CreateCourseWithInitialSnapshot(
 		ctx context.Context,
-		tx *sqlx.Tx,
 		model *CreateCourse,
 		ownerID uuid.UUID,
 	) (*Course, error)
@@ -120,10 +114,12 @@ type Repo interface {
 		update *UpdateCourse,
 	) (*Course, error)
 	DeleteCourseByID(ctx context.Context, id uuid.UUID) error
-	PublishSnapshotToCourse(
+	// PublishDraft atomically links the draft snapshot as the course's active
+	// snapshot (checking the optimistic lock) and marks it published.
+	PublishDraft(
 		ctx context.Context,
-		tx *sqlx.Tx,
-		model *PublishSnapshot,
+		courseID, draftSnapshotID uuid.UUID,
+		expectedVersion int,
 	) error
 	CreateInvite(
 		ctx context.Context,

--- a/internal/courses/service.go
+++ b/internal/courses/service.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jmoiron/sqlx"
 	"go.uber.org/zap"
 
 	"github.com/dsc-sgu/mm-backend/internal/courses/locks"
@@ -19,20 +18,17 @@ type Service struct {
 	repo             Repo
 	snapshotsService *snapshots.Service
 	locksService     *locks.Service
-	txManager        TxManager
 }
 
 func NewService(
 	repo Repo,
 	snapshotsService *snapshots.Service,
 	locksService *locks.Service,
-	txManager TxManager,
 ) *Service {
 	return &Service{
 		repo:             repo,
 		snapshotsService: snapshotsService,
 		locksService:     locksService,
-		txManager:        txManager,
 	}
 }
 
@@ -69,11 +65,6 @@ var (
 	)
 )
 
-// TxManager is an interface for executing transactions on the service level
-type TxManager interface {
-	ExecInTx(ctx context.Context, fn func(tx *sqlx.Tx) error) error
-}
-
 func (s *Service) CheckCourseMember(
 	ctx context.Context,
 	userID, courseID uuid.UUID,
@@ -93,50 +84,7 @@ func (s *Service) CreateCourse(
 	model *CreateCourse,
 	ownerID uuid.UUID,
 ) (*Course, error) {
-	var createdCourse *Course
-
-	err := s.txManager.ExecInTx(ctx, func(tx *sqlx.Tx) error {
-		var txErr error
-
-		createdCourse, txErr = s.repo.CreateCourse(ctx, tx, model, ownerID)
-		if txErr != nil {
-			return fmt.Errorf("create course: %w", txErr)
-		}
-
-		firstSnapshot := &snapshots.Snapshot{
-			CourseID:  createdCourse.ID,
-			Version:   1,
-			Status:    snapshots.PublishedStatus,
-			CreatedBy: ownerID,
-			CreatedAt: time.Now(),
-		}
-
-		_, txErr = s.snapshotsService.CreateSnapshot(ctx, tx, firstSnapshot)
-		if txErr != nil {
-			return fmt.Errorf("create initial snapshot: %w", txErr)
-		}
-
-		publishModel := &PublishSnapshot{
-			CourseID:        createdCourse.ID,
-			NewSnapshotID:   firstSnapshot.ID,
-			ExpectedVersion: 0,
-		}
-
-		txErr = s.repo.PublishSnapshotToCourse(ctx, tx, publishModel)
-		if txErr != nil {
-			return fmt.Errorf("link initial snapshot: %w", txErr)
-		}
-
-		createdCourse.ActiveSnapshotID = &firstSnapshot.ID
-		createdCourse.Version = 1
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return createdCourse, nil
+	return s.repo.CreateCourseWithInitialSnapshot(ctx, model, ownerID)
 }
 
 func (s *Service) CreateInvite(
@@ -283,22 +231,16 @@ func (s *Service) LockAndInitDraft(
 	}
 
 	// Case 3: Draft does not exist, create a new one
-	var newDraft *snapshots.Snapshot
-	err = s.txManager.ExecInTx(ctx, func(tx *sqlx.Tx) error {
-		var txErr error
-		targetVersion := course.Version + 1
-		newDraft, txErr = s.snapshotsService.CreateDraftFromActual(
-			ctx,
-			tx,
-			session.CourseID,
-			targetVersion,
-			session.UserID,
-			*course.ActiveSnapshotID,
-		)
-		return txErr
-	})
+	targetVersion := course.Version + 1
+	newDraft, err := s.snapshotsService.CreateDraftFromActual(
+		ctx,
+		session.CourseID,
+		targetVersion,
+		session.UserID,
+		*course.ActiveSnapshotID,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("lock and init: create draft tx: %w", err)
+		return nil, fmt.Errorf("lock and init: create draft: %w", err)
 	}
 
 	return &InitLockResult{
@@ -349,14 +291,11 @@ func (s *Service) SwitchSnapshot(
 	}
 
 	// Replace draft blocks with target
-	return s.txManager.ExecInTx(ctx, func(tx *sqlx.Tx) error {
-		return s.snapshotsService.SwitchSnapshotContent(
-			ctx,
-			tx,
-			draft.ID,
-			targetSnapshotID,
-		)
-	})
+	return s.snapshotsService.SwitchSnapshotContent(
+		ctx,
+		draft.ID,
+		targetSnapshotID,
+	)
 }
 
 // PublishDraft checks optimistic lock, fixes editings,
@@ -381,32 +320,15 @@ func (s *Service) PublishDraft(
 		return ErrDraftNotFound
 	}
 
-	publishSnapshot := &PublishSnapshot{
-		CourseID:        session.CourseID,
-		NewSnapshotID:   draftSnapshotID,
-		ExpectedVersion: draft.Version - 1,
+	err = s.repo.PublishDraft(
+		ctx,
+		session.CourseID,
+		draftSnapshotID,
+		draft.Version-1,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrSnapshotConflict
 	}
-
-	err = s.txManager.ExecInTx(ctx, func(tx *sqlx.Tx) error {
-		txErr := s.repo.PublishSnapshotToCourse(
-			ctx,
-			tx,
-			publishSnapshot,
-		)
-		if txErr != nil {
-			if errors.Is(txErr, sql.ErrNoRows) {
-				return ErrSnapshotConflict
-			}
-			return txErr
-		}
-
-		return s.snapshotsService.UpdateSnapshotStatus(
-			ctx,
-			tx,
-			draftSnapshotID,
-			snapshots.PublishedStatus,
-		)
-	})
 	if err != nil {
 		return err
 	}
@@ -436,11 +358,8 @@ func (s *Service) CancelEdit(
 		return s.locksService.Unlock(ctx, session)
 	}
 
-	err = s.txManager.ExecInTx(ctx, func(tx *sqlx.Tx) error {
-		return s.snapshotsService.DiscardDraft(ctx, tx, draft.ID)
-	})
-	if err != nil {
-		return fmt.Errorf("cancel edit: discard draft tx: %w", err)
+	if err := s.snapshotsService.DiscardDraft(ctx, draft.ID); err != nil {
+		return fmt.Errorf("cancel edit: discard draft: %w", err)
 	}
 
 	return s.locksService.Unlock(ctx, session)

--- a/internal/pg/courses.go
+++ b/internal/pg/courses.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/dsc-sgu/mm-backend/internal/courses"
+	"github.com/dsc-sgu/mm-backend/internal/snapshots"
 )
 
 const (
@@ -115,7 +116,60 @@ func (r *PGRepo) ExecInTx(
 	return tx.Commit()
 }
 
-func (r *PGRepo) CreateCourse(
+// CreateCourseWithInitialSnapshot atomically creates a course together with
+// its first published snapshot and links them.
+func (r *PGRepo) CreateCourseWithInitialSnapshot(
+	ctx context.Context,
+	model *courses.CreateCourse,
+	ownerID uuid.UUID,
+) (*courses.Course, error) {
+	var createdCourse *courses.Course
+
+	err := r.ExecInTx(ctx, func(tx *sqlx.Tx) error {
+		var txErr error
+
+		createdCourse, txErr = r.createCourseTx(ctx, tx, model, ownerID)
+		if txErr != nil {
+			return fmt.Errorf("create course: %w", txErr)
+		}
+
+		firstSnapshot := &snapshots.Snapshot{
+			CourseID:  createdCourse.ID,
+			Version:   1,
+			Status:    snapshots.PublishedStatus,
+			CreatedBy: ownerID,
+			CreatedAt: time.Now(),
+		}
+
+		createdSnapshot, txErr := r.CreateSnapshot(ctx, tx, firstSnapshot)
+		if txErr != nil {
+			return fmt.Errorf("create initial snapshot: %w", txErr)
+		}
+
+		txErr = r.publishSnapshotToCourseTx(
+			ctx,
+			tx,
+			createdCourse.ID,
+			createdSnapshot.ID,
+			0,
+		)
+		if txErr != nil {
+			return fmt.Errorf("link initial snapshot: %w", txErr)
+		}
+
+		createdCourse.ActiveSnapshotID = &createdSnapshot.ID
+		createdCourse.Version = 1
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return createdCourse, nil
+}
+
+func (r *PGRepo) createCourseTx(
 	ctx context.Context,
 	tx *sqlx.Tx,
 	model *courses.CreateCourse,
@@ -266,10 +320,38 @@ func (r *PGRepo) UpdateCourseByID(
 	return &course, nil
 }
 
-func (r *PGRepo) PublishSnapshotToCourse(
+// PublishDraft atomically links the draft snapshot as the course's active
+// snapshot (checking the optimistic lock) and marks it published.
+func (r *PGRepo) PublishDraft(
+	ctx context.Context,
+	courseID, draftSnapshotID uuid.UUID,
+	expectedVersion int,
+) error {
+	return r.ExecInTx(ctx, func(tx *sqlx.Tx) error {
+		if err := r.publishSnapshotToCourseTx(
+			ctx,
+			tx,
+			courseID,
+			draftSnapshotID,
+			expectedVersion,
+		); err != nil {
+			return err
+		}
+
+		return r.UpdateSnapshotStatus(
+			ctx,
+			tx,
+			draftSnapshotID,
+			snapshots.PublishedStatus,
+		)
+	})
+}
+
+func (r *PGRepo) publishSnapshotToCourseTx(
 	ctx context.Context,
 	tx *sqlx.Tx,
-	model *courses.PublishSnapshot,
+	courseID, newSnapshotID uuid.UUID,
+	expectedVersion int,
 ) error {
 	zap.L().
 		Debug("Executing query within transaction", zap.String("query", publishSnapshotToCourseSQL))
@@ -277,9 +359,9 @@ func (r *PGRepo) PublishSnapshotToCourse(
 	res, err := tx.ExecContext(
 		ctx,
 		publishSnapshotToCourseSQL,
-		model.NewSnapshotID,
-		model.CourseID,
-		model.ExpectedVersion,
+		newSnapshotID,
+		courseID,
+		expectedVersion,
 	)
 	if err != nil {
 		return fmt.Errorf("tx publish course version: %w", err)

--- a/internal/pg/snapshots.go
+++ b/internal/pg/snapshots.go
@@ -150,6 +150,7 @@ func (r *PGRepo) FindUserDraft(
 	return &snapshot, nil
 }
 
+// UpdateSnapshotStatus updates a snapshot's status within an existing transaction.
 func (r *PGRepo) UpdateSnapshotStatus(
 	ctx context.Context,
 	tx *sqlx.Tx,
@@ -171,29 +172,34 @@ func (r *PGRepo) UpdateSnapshotStatus(
 	return nil
 }
 
-// CreateDraftFromActual creates draft from actual snapshot and copies all blocks to it
+// CreateDraftFromActual atomically creates a draft from the actual snapshot
+// and copies all its blocks into the draft.
 func (r *PGRepo) CreateDraftFromActual(
 	ctx context.Context,
-	tx *sqlx.Tx,
 	courseID uuid.UUID,
 	targetVersion int,
 	userID uuid.UUID,
 	actualSnapshotID uuid.UUID,
 ) (*snapshots.Snapshot, error) {
-	draft := &snapshots.Snapshot{
-		CourseID:  courseID,
-		Version:   targetVersion,
-		Status:    snapshots.DraftStatus,
-		CreatedBy: userID,
-		CreatedAt: time.Now(),
-	}
+	var createdDraft *snapshots.Snapshot
 
-	createdDraft, err := r.CreateSnapshot(ctx, tx, draft)
-	if err != nil {
-		return nil, err
-	}
+	err := r.ExecInTx(ctx, func(tx *sqlx.Tx) error {
+		draft := &snapshots.Snapshot{
+			CourseID:  courseID,
+			Version:   targetVersion,
+			Status:    snapshots.DraftStatus,
+			CreatedBy: userID,
+			CreatedAt: time.Now(),
+		}
 
-	err = r.CopyBlocksToSnapshot(ctx, tx, actualSnapshotID, createdDraft.ID)
+		var txErr error
+		createdDraft, txErr = r.CreateSnapshot(ctx, tx, draft)
+		if txErr != nil {
+			return txErr
+		}
+
+		return r.CopyBlocksToSnapshot(ctx, tx, actualSnapshotID, createdDraft.ID)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("tx copy blocks to new snapshot: %w", err)
 	}
@@ -201,35 +207,35 @@ func (r *PGRepo) CreateDraftFromActual(
 	return createdDraft, nil
 }
 
-// SwitchSnapshotContent deletes current draft blocks and copies blocks from target snapshot
+// SwitchSnapshotContent atomically deletes the current draft's blocks and
+// copies blocks from the target snapshot.
 func (r *PGRepo) SwitchSnapshotContent(
 	ctx context.Context,
-	tx *sqlx.Tx,
 	draftSnapshotID uuid.UUID,
 	targetSnapshotID uuid.UUID,
 ) error {
-	zap.L().
-		Debug("Executing block delete query within transaction", zap.String("query", deleteAllBlocksBySnapshotIdSQL))
+	return r.ExecInTx(ctx, func(tx *sqlx.Tx) error {
+		zap.L().
+			Debug("Executing block delete query within transaction", zap.String("query", deleteAllBlocksBySnapshotIdSQL))
 
-	// Delete current draft blocks
-	err := r.DeleteAllBlocksBySnapshotID(ctx, tx, draftSnapshotID)
-	if err != nil {
-		return fmt.Errorf(
-			"tx delete current draft blocks: %w",
-			err,
-		)
-	}
+		// Delete current draft blocks
+		if err := r.DeleteAllBlocksBySnapshotID(ctx, tx, draftSnapshotID); err != nil {
+			return fmt.Errorf(
+				"tx delete current draft blocks: %w",
+				err,
+			)
+		}
 
-	zap.L().
-		Debug("Executing block copying query within transaction", zap.String("query", copyBlocksToSnapshotSQL))
+		zap.L().
+			Debug("Executing block copying query within transaction", zap.String("query", copyBlocksToSnapshotSQL))
 
-	// Copy blocks from target
-	err = r.CopyBlocksToSnapshot(ctx, tx, targetSnapshotID, draftSnapshotID)
-	if err != nil {
-		return fmt.Errorf("tx copy blocks from target to draft: %w", err)
-	}
+		// Copy blocks from target
+		if err := r.CopyBlocksToSnapshot(ctx, tx, targetSnapshotID, draftSnapshotID); err != nil {
+			return fmt.Errorf("tx copy blocks from target to draft: %w", err)
+		}
 
-	return nil
+		return nil
+	})
 }
 
 // DeleteAllSnapshotsByCourseID marks all snapshots of a course as 'stale'. It is used for a cascading soft deletion of a course.
@@ -252,28 +258,29 @@ func (r *PGRepo) DeleteAllSnapshotsByCourseID(
 	return nil
 }
 
-// DiscardDraft marks draft snapshot as 'stale' and deletes all it's blocks
+// DiscardDraft atomically marks the draft snapshot as 'stale' and deletes all its blocks.
 func (r *PGRepo) DiscardDraft(
 	ctx context.Context,
-	tx *sqlx.Tx,
 	draftSnapshotID uuid.UUID,
 ) error {
-	if err := r.UpdateSnapshotStatus(
-		ctx,
-		tx,
-		draftSnapshotID,
-		snapshots.StaleStatus,
-	); err != nil {
-		return fmt.Errorf("discard draft update status: %w", err)
-	}
+	return r.ExecInTx(ctx, func(tx *sqlx.Tx) error {
+		if err := r.UpdateSnapshotStatus(
+			ctx,
+			tx,
+			draftSnapshotID,
+			snapshots.StaleStatus,
+		); err != nil {
+			return fmt.Errorf("discard draft update status: %w", err)
+		}
 
-	if err := r.DeleteAllBlocksBySnapshotID(
-		ctx,
-		tx,
-		draftSnapshotID,
-	); err != nil {
-		return fmt.Errorf("discard draft deleting blocks: %w", err)
-	}
+		if err := r.DeleteAllBlocksBySnapshotID(
+			ctx,
+			tx,
+			draftSnapshotID,
+		); err != nil {
+			return fmt.Errorf("discard draft deleting blocks: %w", err)
+		}
 
-	return nil
+		return nil
+	})
 }

--- a/internal/snapshots/repo.go
+++ b/internal/snapshots/repo.go
@@ -27,11 +27,6 @@ type Snapshot struct {
 }
 
 type Repo interface {
-	CreateSnapshot(
-		ctx context.Context,
-		tx *sqlx.Tx,
-		snapshot *Snapshot,
-	) (*Snapshot, error)
 	GetSnapshotByID(ctx context.Context, id uuid.UUID) (*Snapshot, error)
 	GetPublishedSnapshotsByCourseID(
 		ctx context.Context,
@@ -41,23 +36,19 @@ type Repo interface {
 		ctx context.Context,
 		courseID, userID uuid.UUID,
 	) (*Snapshot, error)
-	UpdateSnapshotStatus(
-		ctx context.Context,
-		tx *sqlx.Tx,
-		id uuid.UUID,
-		status Status,
-	) error
+	// CreateDraftFromActual atomically creates a draft snapshot and copies
+	// all blocks from the actual snapshot into it.
 	CreateDraftFromActual(
 		ctx context.Context,
-		tx *sqlx.Tx,
 		courseID uuid.UUID,
 		targetVersion int,
 		userID uuid.UUID,
 		actualSnapshotID uuid.UUID,
 	) (*Snapshot, error)
+	// SwitchSnapshotContent atomically replaces the draft's blocks with the
+	// target snapshot's blocks.
 	SwitchSnapshotContent(
 		ctx context.Context,
-		tx *sqlx.Tx,
 		draftSnapshotID uuid.UUID,
 		targetSnapshotID uuid.UUID,
 	) error
@@ -66,9 +57,10 @@ type Repo interface {
 		tx *sqlx.Tx,
 		courseID uuid.UUID,
 	) error
+	// DiscardDraft atomically marks the draft snapshot as stale and deletes
+	// all its blocks.
 	DiscardDraft(
 		ctx context.Context,
-		tx *sqlx.Tx,
 		draftSnapshotID uuid.UUID,
 	) error
 }

--- a/internal/snapshots/service.go
+++ b/internal/snapshots/service.go
@@ -15,14 +15,6 @@ func NewService(repo Repo) *Service {
 	return &Service{repo: repo}
 }
 
-func (s *Service) CreateSnapshot(
-	ctx context.Context,
-	tx *sqlx.Tx,
-	snapshot *Snapshot,
-) (*Snapshot, error) {
-	return s.repo.CreateSnapshot(ctx, tx, snapshot)
-}
-
 func (s *Service) GetSnapshotByID(
 	ctx context.Context,
 	id uuid.UUID,
@@ -44,18 +36,8 @@ func (s *Service) FindUserDraft(
 	return s.repo.FindUserDraft(ctx, courseID, userID)
 }
 
-func (s *Service) UpdateSnapshotStatus(
-	ctx context.Context,
-	tx *sqlx.Tx,
-	id uuid.UUID,
-	status Status,
-) error {
-	return s.repo.UpdateSnapshotStatus(ctx, tx, id, status)
-}
-
 func (s *Service) CreateDraftFromActual(
 	ctx context.Context,
-	tx *sqlx.Tx,
 	courseID uuid.UUID,
 	targetVersion int,
 	userID uuid.UUID,
@@ -63,7 +45,6 @@ func (s *Service) CreateDraftFromActual(
 ) (*Snapshot, error) {
 	return s.repo.CreateDraftFromActual(
 		ctx,
-		tx,
 		courseID,
 		targetVersion,
 		userID,
@@ -73,13 +54,11 @@ func (s *Service) CreateDraftFromActual(
 
 func (s *Service) SwitchSnapshotContent(
 	ctx context.Context,
-	tx *sqlx.Tx,
 	draftSnapshotID uuid.UUID,
 	targetSnapshotID uuid.UUID,
 ) error {
 	return s.repo.SwitchSnapshotContent(
 		ctx,
-		tx,
 		draftSnapshotID,
 		targetSnapshotID,
 	)
@@ -95,8 +74,7 @@ func (s *Service) DeleteAllSnapshotsByCourseID(
 
 func (s *Service) DiscardDraft(
 	ctx context.Context,
-	tx *sqlx.Tx,
 	draftSnapshotID uuid.UUID,
 ) error {
-	return s.repo.DiscardDraft(ctx, tx, draftSnapshotID)
+	return s.repo.DiscardDraft(ctx, draftSnapshotID)
 }


### PR DESCRIPTION
Composite writes (course+snapshot linking, draft create/switch/discard) now open their own tx inside PGRepo instead of courses.Service passing a shared *sqlx.Tx into other services.